### PR TITLE
Fix CursorWidget hardcoded size preventing proper cursor rendering

### DIFF
--- a/lib/src/modules/waveform/view/widgets/cursor.dart
+++ b/lib/src/modules/waveform/view/widgets/cursor.dart
@@ -18,7 +18,7 @@ class CursorWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return CustomPaint(
-      size: const Size(100, 100),
+      
       painter: Cursor(position),
     );
   }


### PR DESCRIPTION
## Problem

The `CursorWidget` uses a hardcoded size of 100x100 pixels instead of adapting to the actual waveform display area. This causes the cursor to be rendered at a fixed size regardless of the actual display dimensions, making it unusable for waveform displays of different sizes.

## Solution

Remove the hardcoded `size` parameter from the `CustomPaint` widget. When no size is specified, `CustomPaint` will size itself to fit its parent's constraints, allowing it to adapt to the waveform display area.

## Changes

- **File**: `lib/src/modules/waveform/view/widgets/cursor.dart`
- **Change**: Removed `size: const Size(100, 100),` from the `CustomPaint` widget

## Testing

The cursor should now properly scale and position itself within waveform displays of any size.

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.